### PR TITLE
Job announcements

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ from typing import List
 from model import Model
 import strapi
 from matcher import Matcher
+from job_announce_checker import JobAnnounceChecker
 import requests
 import json
 
@@ -64,6 +65,11 @@ async def get_channel_by_id(channel_id: str):
     except discord.errors.HTTPException:
         return
 
+def check_job_announcement(message: str):
+    job_checker = JobAnnounceChecker()
+    is_job = job_checker.check_message(message=message)
+    return is_job
+    
 intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True
@@ -119,7 +125,9 @@ async def on_message(message):
             await message.channel.send(me.guild_permissions.text())
             
     else:
-        pass
+        is_job_announcement = check_job_announcement(message=message.content)
+        if(is_job_announcement):
+            await message.reply('<@&1086370714354995342>')
 
 
 client.run(os.getenv("BOT_TOKEN"))

--- a/dateStore.py
+++ b/dateStore.py
@@ -7,16 +7,16 @@ class LastDate():
         self.last_date = last_date
 
 
-def save_last_date(obj: LastDate):
+def save_last_date(obj: LastDate, filename: str = "last_date.pkl"):
     try:
-        with open("last_date.pickle", "wb") as f:
+        with open(filename, "wb") as f:
             pickle.dump(obj=obj, file=f, protocol=pickle.HIGHEST_PROTOCOL)
     except Exception as e:
         print(e)
 
-def load_last_date():
+def load_last_date(filename: str = "last_date.pkl"):
     try:
-        with open("last_date.pickle", "rb") as f:
+        with open(filename, "rb") as f:
             return pickle.load(f)
     except Exception as e:
         print(e)

--- a/job_announce_checker.py
+++ b/job_announce_checker.py
@@ -1,0 +1,31 @@
+import os
+import requests
+from dotenv import load_dotenv
+import openai
+import json
+load_dotenv()
+
+class JobAnnounceChecker:
+    def __init__(self) -> None:
+        openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.base_prompt = "Identifique se a mensagem abaixo é um anúncio de vaga, golpe ou venda de algum produto. Geralmente envolvem oferecer muito dinheiro em pouco tempo, anúncio de cursos, vagas ou produtos. Retorne apenas 'true' ou 'false' sem linhas novas ou outros caracteres. Considere mensagens em inglês.\nMensagem: "
+        pass
+
+    def check_message(self, message: str) -> bool:
+        final_prompt = self.base_prompt + message
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}"
+        }
+        print(type(headers))
+        res = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers=headers,
+            data=json.dumps({
+            "model": "gpt-3.5-turbo",
+            "messages": [{"role": "user", "content": final_prompt}],
+            "temperature": 0.2
+            })
+        )
+        res = res.json()["choices"][0]["message"]["content"]
+        return True if res == 'true' else False

--- a/job_announce_checker.py
+++ b/job_announce_checker.py
@@ -15,17 +15,12 @@ class JobAnnounceChecker:
         final_prompt = self.base_prompt + message
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}"
+            "Authorization": f"{os.getenv('API_KEY')}"
         }
-        print(type(headers))
-        res = requests.post(
-            "https://api.openai.com/v1/chat/completions",
-            headers=headers,
-            data=json.dumps({
-            "model": "gpt-3.5-turbo",
-            "messages": [{"role": "user", "content": final_prompt}],
-            "temperature": 0.2
-            })
-        )
-        res = res.json()["choices"][0]["message"]["content"]
-        return True if res == 'true' else False
+        
+        req_body = {
+        "prompt": final_prompt
+        }
+        res = requests.post(url="https://data-miners.onrender.com/predict", data=json.dumps(req_body), headers=headers)
+
+        return True if res == 'spam' else False

--- a/model.py
+++ b/model.py
@@ -35,7 +35,7 @@ class Model:
   def remove_characters(self, responses: List) -> List:
     formated = []
     for response in responses:
-      res = re.sub('[\., \,, \/, \-, _]', '', response)
+      res = re.sub(r'[\., \,, \/, \-, _]', '', response)
       formated.append(res)
     return formated
   

--- a/test_date_store.py
+++ b/test_date_store.py
@@ -1,0 +1,40 @@
+from dateStore import LastDate, save_last_date, load_last_date
+import datetime
+import os
+import pytest
+
+FILENAME = "test.pkl"
+
+def test_last_date_creation():
+    last_date = LastDate(datetime.datetime.now())
+    assert last_date.last_date == datetime.datetime.now()
+
+
+def test_last_date_not_null():
+    try:
+        last_date_null = LastDate()
+    except TypeError:
+        assert TypeError != None
+
+
+def test_last_save_dating():
+    last_date = LastDate(datetime.datetime.now())
+    save_last_date(last_date, FILENAME)
+    assert os.path.exists(FILENAME)
+
+
+def test_last_save_reading():
+    now_ = datetime.datetime.now()
+    last_date = LastDate(now_)
+    save_last_date(last_date, FILENAME)
+    loaded_obj = load_last_date(FILENAME)
+    assert type(loaded_obj) == LastDate
+    assert loaded_obj.last_date == now_
+
+
+@pytest.fixture(autouse=True)
+def cleanup(request):
+    yield # run tests before this
+    if os.path.exists(FILENAME):
+        os.remove(FILENAME)
+    

--- a/test_model.py
+++ b/test_model.py
@@ -1,0 +1,22 @@
+import pytest
+from model import Model
+
+jobs_list = ["dev"]
+techs_list = ["c"]
+prompts = ["sou dev trabalho com c"]
+
+def test_model_creation():
+    model = Model(jobs_list=jobs_list, techs_list=techs_list, prompts=prompts)
+
+    assert model.jobs_list == jobs_list
+    assert model.techs_list == techs_list
+    assert model.prompts == prompts
+    for job, tech in zip(jobs_list, techs_list):
+        assert job in model.base_prompt
+        assert tech in model.base_prompt
+
+def test_characters_removal():
+    model = Model(jobs_list=jobs_list, techs_list=techs_list, prompts=prompts)
+    responses = ["{a : b},.", "{c : d -}"]
+    correct_responses = ["{a:b}", "{c:d}"]
+    assert model.remove_characters(responses=responses) == correct_responses


### PR DESCRIPTION
This PR implements a way to listen for every message and check for job announcements on it. This approach uses OpenAI API with model gpt-3.5-turbo to achieve this moderation on our discord.

We call the API for every message and mention admins if the message is classified as a job announcement.

## Pricing

This approach would cost:
prompt - 300 tokens
message - N tokens
gpt-3.5-turbo - $0.002 (or R$0.01) per 1K tokens.
This way, processing 100 messages would cost R$1,00

## Other possible approaches

Create a good classification model just for this purpose. It would be cheaper than using the openAI api, since it is a pretty simple model that we can create ourselves. The problem is that we don't have enough training data to build a good classification model. I am researching where we can get this that.